### PR TITLE
Added Simple driver which returns an array. Reader now abstract class

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,17 @@ $ composer require renedekat/blmreader
 ## Usage
 
 ``` php
-$blmReader = Reader::create()->loadFromFile("path/to/blmFile")
-// OR
-$blmReader = Reader::create()->loadFromString($blmContents)
+use Renedekat\Blm\Drivers\Simple
 
-$rawContents = $blmReader->getRawContents();
-$collection = $blmReader->getDate();
-$array = $blmReader->toArray();
+$simple = Simple::create()->loadFromFile("path/to/blmFile")
+// OR
+$simple = Simple::create()->loadFromString($blmContents)
+
+$rawContents = $simple->getRawContents();
+$output = $simple->geOutput();
+$data = $output['data'];
+$definitions = $output['definitions']
+$headers = $output['headers;
 
 ```
 

--- a/src/Drivers/Simple.php
+++ b/src/Drivers/Simple.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Renedekat\Blm\Drivers;
+
+use Renedekat\Blm\Reader;
+
+class Simple extends Reader
+{
+
+    /**
+     * Return the output as an array containing the keys: headers, definitions and data
+     * @return array
+     */
+    public function getOutput()
+    {
+        return [
+            'headers' => $this->getHeaders()->toArray(),
+            'definitions' => $this->getDefinitions()->toArray(),
+            'data' => $this->getData()->toArray()
+        ];
+    }
+}

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -8,7 +8,7 @@ use Renedekat\Blm\Exceptions\InvalidBlmStringException;
 use Renedekat\PHPVerbalExpressions\VerbalExpressions;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 
-class Reader
+abstract class Reader
 {
     const CONTAINS_HEADERS = 1;
     const CONTAINS_DEFINITIONS = 2;
@@ -17,22 +17,22 @@ class Reader
     /**
      * @var string Raw contents
      */
-    protected $contents = null;
+    private $contents = null;
 
     /**
      * @var Collection Parsed header
      */
-    protected $headers = null;
+    private $headers = null;
 
     /**
      * @var Collection Parsed definition
      */
-    protected $definitions = null;
+    private $definitions = null;
 
     /**
      * @var Collection Parsed data
      */
-    protected $data = null;
+    private $data = null;
 
     /**
      * @return Reader
@@ -48,7 +48,7 @@ class Reader
      * @throws FileNotFoundException
      * @throws InvalidBlmFileException
      */
-    public function loadFromFile($filePath)
+    final public function loadFromFile($filePath)
     {
         if (!file_exists($filePath)) {
             throw new FileNotFoundException();
@@ -68,7 +68,7 @@ class Reader
      * @return Reader
      * @throws InvalidBlmFileException
      */
-    public function loadFromString($contents)
+    final public function loadFromString($contents)
     {
         if (!$this->containsValidBLM($contents)) {
             throw new InvalidBlmStringException('Invalid BLM content found.');
@@ -78,9 +78,15 @@ class Reader
     }
 
     /**
+     * Return the output in the drivers format
+     * @return mixed
+     */
+    abstract public function getOutput();
+
+    /**
      * @return string
      */
-    public function getRawContents()
+    final public function getRawContents()
     {
         return $this->contents;
     }
@@ -88,7 +94,7 @@ class Reader
     /**
      * @return Collection
      */
-    public function getHeaders()
+    final protected function getHeaders()
     {
         return $this->headers;
     }
@@ -96,7 +102,7 @@ class Reader
     /**
      * @return Collection
      */
-    public function getDefinitions()
+    final protected function getDefinitions()
     {
         return $this->definitions;
     }
@@ -104,7 +110,7 @@ class Reader
     /**
      * @return Collection
      */
-    public function getData()
+    final protected function getData()
     {
         return $this->data;
     }
@@ -115,7 +121,7 @@ class Reader
      * @param string $contents
      * @return bool Returns true if content is valid
      */
-    protected function containsValidBLM($contents)
+    final protected function containsValidBLM($contents)
     {
         $contains = $this->containsHeader($contents) ? self::CONTAINS_HEADERS : 0;
         $contains += $this->containsDefinition($contents) ? self::CONTAINS_DEFINITIONS : 0;
@@ -131,7 +137,7 @@ class Reader
      * @param string $contents
      * @return bool
      */
-    protected function containsHeader($contents)
+    final protected function containsHeader($contents)
     {
         return (bool) $this->getRegexFor('#HEADER#')->test($contents);
     }
@@ -141,7 +147,7 @@ class Reader
      * @param string $contents
      * @return bool
      */
-    protected function containsDefinition($contents)
+    final protected function containsDefinition($contents)
     {
         return (bool) $this->getRegexFor('#DEFINITION#')->test($contents);
     }
@@ -151,7 +157,7 @@ class Reader
      * @param string $contents
      * @return bool
      */
-    protected function containsData($contents)
+    final protected function containsData($contents)
     {
         return (bool) $this->getRegexFor('#DATA#')->test($contents);
     }
@@ -160,7 +166,7 @@ class Reader
      * @param string $contents
      * @return Reader
      */
-    protected function parse($contents)
+    final protected function parse($contents)
     {
         $this->contents = $contents;
 
@@ -177,7 +183,7 @@ class Reader
      * Parses the #HEADER# section of the BLM file and stores it in $this->headers
      * @param string $contents
      */
-    protected function parseHeader($contents)
+    private function parseHeader($contents)
     {
         preg_match($this->getRegexFor('#HEADER#'), $contents, $match);
 
@@ -201,7 +207,7 @@ class Reader
      * Parses the #DEFINITION# section of the BLM file and stores it in $this->definitions
      * @param string $contents
      */
-    protected function parseDefinition($contents)
+    private function parseDefinition($contents)
     {
         preg_match($this->getRegexFor('#DEFINITION#'), $contents, $match);
 
@@ -224,7 +230,7 @@ class Reader
      * Parses the #DATA# section of the BLM file and stores it in $this->data
      * @param $contents
      */
-    protected function parseData($contents)
+    private function parseData($contents)
     {
         preg_match($this->getRegexFor('#DATA#'), $contents, $match);
 

--- a/tests/BlmParserTest.php
+++ b/tests/BlmParserTest.php
@@ -2,15 +2,13 @@
 
 namespace Renedekat\Blm\Test;
 
-use Illuminate\Support\Collection;
 use PHPUnit_Framework_TestCase;
-use Renedekat\Blm\Reader;
+use Renedekat\Blm\Drivers\Simple;
 use Renedekat\Blm\Exceptions\InvalidBlmFileException;
 use Renedekat\Blm\Exceptions\InvalidBlmStringException;
 
 class BlmParserTest extends PHPUnit_Framework_TestCase
 {
-
 
     /**
      * @test
@@ -21,17 +19,11 @@ class BlmParserTest extends PHPUnit_Framework_TestCase
 
         $contents = file_get_contents($blmFile);
 
-        $reader = Reader::create()->loadFromFile($blmFile);
+        $simple = Simple::create()->loadFromFile($blmFile);
 
-        $this->assertInstanceOf(Reader::class, $reader);
+        $this->assertInstanceOf(Simple::class, $simple);
 
-        $this->assertEquals($contents, $reader->getRawContents());
-
-        $this->assertInstanceOf(Collection::class, $reader->getHeaders());
-
-        $this->assertInstanceOf(Collection::class, $reader->getDefinitions());
-
-        $this->assertInstanceOf(Collection::class, $reader->getData());
+        $this->assertEquals($contents, $simple->getRawContents());
     }
 
     /**
@@ -41,7 +33,7 @@ class BlmParserTest extends PHPUnit_Framework_TestCase
     {
         $this->expectException(InvalidBlmFileException::class);
 
-        Reader::create()->loadFromFile(dirname(__FILE__) . '/invalid.blm');
+        Simple::create()->loadFromFile(dirname(__FILE__) . '/invalid.blm');
     }
 
     /**
@@ -51,17 +43,29 @@ class BlmParserTest extends PHPUnit_Framework_TestCase
     {
         $contents = file_get_contents(dirname(__FILE__) . '/valid.blm');
 
-        $reader = Reader::create()->loadFromString($contents);
+        $simple = Simple::create()->loadFromString($contents);
 
-        $this->assertInstanceOf(Reader::class, $reader);
+        $this->assertInstanceOf(Simple::class, $simple);
 
-        $this->assertEquals($contents, $reader->getRawContents());
+        $this->assertEquals($contents, $simple->getRawContents());
+    }
 
-        $this->assertInstanceOf(Collection::class, $reader->getHeaders());
+    /**
+     * @test
+     */
+    public function gets_simple_valid_output()
+    {
+        $simple = Simple::create()->loadFromFile(dirname(__FILE__) . '/valid.blm');
 
-        $this->assertInstanceOf(Collection::class, $reader->getDefinitions());
+        $output = $simple->getOutput();
 
-        $this->assertInstanceOf(Collection::class, $reader->getData());
+        $this->assertArrayHasKey('headers', $output);
+
+        $this->assertArrayHasKey('definitions', $output);
+
+        $this->assertArrayHasKey('data', $output);
+
+        $this->assertEquals($this->getExpectedData(), $output['data']);
     }
 
     /**
@@ -73,7 +77,7 @@ class BlmParserTest extends PHPUnit_Framework_TestCase
 
         $blmContents = file_get_contents(dirname(__FILE__) . '/invalid.blm');
 
-        Reader::create()->loadFromString($blmContents);
+        Simple::create()->loadFromString($blmContents);
     }
 
     /**


### PR DESCRIPTION
## Description

Refactored the Reader class to be abstract with an abstract getOutput method. Added a Simple driver that returns data as an array. The output now contains headers, definitions and data.
## Motivation and context

This has changed, so multiple drivers can be added which adhere to a contract of implementing a getOutput method. 
## How has this been tested?

Updated all tests to use the Simple driver as Reader isn't instantiable any longer.
Added a unit test to compare the output of Simple->getOutput()['data'] with the expected data array
## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
- [x] My code follows the code style of this project.
